### PR TITLE
Implement docker buildtest

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+
+# IDE Related Items
+/.idea
+
+# Git Related Items
+.git
+.gitattributes
+.github
+.gitignore
+.gitmodules
+
+# Other
+LICENSE
+README.md

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# These files should have specific line endings
+*.sh	text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+# IntelliJ
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 
 # IntelliJ
 .idea
+
+# Build artifacts
+build
+
+# Other
+.bash*

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,5 @@
 # IntelliJ
 .idea
 
-# Build artifacts
-build
-
 # Other
 .bash*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 
 # IntelliJ
 .idea
+.vs
+.vscode
 
 # Other
 .bash*

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,12 @@ ENV DEBUG=True
 
 # Package installs/updates:
 RUN yum install epel-release -y
-RUN yum install gcc-c++.x86_64 openssl-devel libcurl-devel zlib-devel cmake3 -y
+RUN yum install cmake3 \
+    gcc-c++.x86_64 \
+    libcurl-devel \
+    make \
+    openssl-devel \
+    zlib-devel -y
 
 # Prepare entrypoint:
 COPY ./docker-entrypoint.sh ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@
 FROM centos:centos7.9.2009
 
 # Docker container environmental variables:
-ENV HISTFILE=/work/.bash_history_docker
-
-# Docker container environmental variables:
 ENV DEBUG=True
+ENV HISTFILE=/work/.bash_history_docker
 
 # Package installs/updates:
 RUN yum install epel-release -y
@@ -20,8 +18,9 @@ RUN yum install cmake3 \
 COPY ./docker-entrypoint.sh ./
 RUN chmod +x ./docker-entrypoint.sh
 
-# Set the work directory:
+# Create the work directory:
 RUN mkdir /work
+WORKDIR /work
 
 # Volumes
 VOLUME [ "/work" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 # syntax=docker/dockerfile:1
 FROM centos:centos7.9.2009
 
+# Docker image build arguments:
+ARG endpoint="https://api.slateci.io:443"
+ARG token
+
 # Docker container environmental variables:
 ENV DEBUG=True
 ENV HISTFILE=/work/.bash_history_docker
+ENV SLATE_API_ENDPOINT=${endpoint}
+ENV SLATE_CLI_TOKEN=${token}
 
 # Package installs/updates:
 RUN yum install epel-release -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+FROM centos:centos7.9.2009
+
+# Docker container environmental variables:
+ENV HISTFILE=/work/.bash_history_docker
+
+# Docker container environmental variables:
+ENV DEBUG=True
+
+# Package installs/updates:
+RUN yum install epel-release -y
+RUN yum install gcc-c++.x86_64 openssl-devel libcurl-devel zlib-devel cmake3 -y
+
+# Prepare entrypoint:
+COPY ./docker-entrypoint.sh ./
+RUN chmod +x ./docker-entrypoint.sh
+
+# Set the work directory:
+RUN mkdir /work
+
+# Volumes
+VOLUME [ "/work" ]
+
+# Run once the container has started:
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Pre-built binaries are available [for Linux](https://jenkins.slateci.io/artifact
 Dependencies
 ============
 
-> **_NOTE:_** Use docker to ignore this section.
+> **_NOTE:_** Use docker and ignore this section.
 
 The following dependencies are required in order to build this application from its source code:
 - gcc (>=4.8.5)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Table of Contents
    1. [Installing dependencies on Ubuntu](#installing-dependencies-on-ubuntu)
    1. [Installing dependencies on FreeBSD](#installing-dependencies-on-freebsd)
 1. [Building](#building)
+   1. [Building Using Docker](#building-using-docker)
+   1. [Building Natively](#building-natively)
 1. [Usage](#usage)
    1. [Configuration](#configuration)
    1. [General](#general)
@@ -51,9 +53,13 @@ Pre-built binaries are available [for Linux](https://jenkins.slateci.io/artifact
 
 Dependencies
 ============
+
+> **_NOTE:_** Use docker to ignore this section.
+
 The following dependencies are required in order to build this application from its source code:
 - gcc (>=4.8.5)
 - CMake (>=3.0.0)
+- Make (>=3.8.2)
 - OpenSSL
 - libcurl
 - zlib
@@ -84,6 +90,43 @@ Installing dependencies on FreeBSD
 
 Building
 ========
+
+Building Using Docker
+------------------------
+
+The `Dockerfile` provides the following build arguments:
+
+| Name       | Required | Description                                                                                 |
+|------------|----------|---------------------------------------------------------------------------------------------|
+| `endpoint` | No       | The Fabric API endpoint. If not specified this will be set to `https://api.slateci.io:443`. |
+| `token`    | Yes      | The SLATE CLI token associated with `endpoint`.                                             |
+
+Build the Docker image while at the root of this repository:
+
+```shell
+docker build --file Dockerfile --build-arg token=<token> --tag slate-cli:latest .
+```
+
+Running the image will create a new tagged container, build `slate`, test it against `endpoint`, and start up `/bin/bash`.
+
+```shell
+[you@host ~]$ docker run -it -v /<repo-location>/:/work slate-cli:latest
+Building the slate executable...
+...
+[ 27%] Linking CXX executable slate
+[100%] Built target slate
+Testing the slate executable...
+Endpoint: https://api.slateci.io:443
+Client Version Server Version
+1234           1234
+[root@container1234 build]$
+```
+
+Access the build artifacts on the host at `/<repo-location>/build/`.
+
+Building Natively
+---------------------
+
 In the slate-remote-client directory:
 
 	mkdir build

--- a/README.md
+++ b/README.md
@@ -122,7 +122,10 @@ Client Version Server Version
 [root@container1234 build]$
 ```
 
-Access the build artifacts on the host at `/<repo-location>/build/`.
+Tips &amp; Tricks:
+* Access the `slate` executable and other build artifacts on the host at `/<repo-location>/build/`.
+* Re-run the image to rebuild.
+* Or execute `cmake` and `make` commands directly in the container's shell.
 
 Building Natively
 ---------------------

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,3 @@
+
+*
+!.gitignore

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,8 @@ then
   touch ./.bash_history_docker
 fi
 
-cd /work/build
+# Build the slate executable:
+cd ./build
 cmake3 ..
 make
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,9 +9,15 @@ then
   touch ./.bash_history_docker
 fi
 
-# Build the slate executable:
+# Building:
+echo "Building the slate executable..."
 cd ./build
 cmake3 ..
 make
+
+# Testing:
+echo "Testing the slate executable..."
+echo Endpoint: $(echo "$SLATE_API_ENDPOINT")
+echo "$(./slate whoami 2>&1 | head -n 2)"
 
 ${1:-/bin/bash}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Enable strict mode:
+set -euo pipefail
+
+# Change directories to mounted work:
+cd /work
+
+# Create the bash history file if necessary:
+if [ ! -f "$HISTFILE" ]
+then
+  touch ./.bash_history_docker
+fi
+
+# Create the build directory if necessary:
+if [ ! -d "./build" ]
+then
+  mkdir ./build
+fi
+
+cd ./build
+cmake3 ..
+make
+
+${1:-/bin/bash}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,22 +3,13 @@
 # Enable strict mode:
 set -euo pipefail
 
-# Change directories to mounted work:
-cd /work
-
 # Create the bash history file if necessary:
 if [ ! -f "$HISTFILE" ]
 then
   touch ./.bash_history_docker
 fi
 
-# Create the build directory if necessary:
-if [ ! -d "./build" ]
-then
-  mkdir ./build
-fi
-
-cd ./build
+cd /work/build
 cmake3 ..
 make
 


### PR DESCRIPTION
Created containerized environment for building and testing the `slate` executable (ref: [Build using Docker](https://github.com/slateci/slate-remote-client/tree/implement-docker-buildtest#building-using-docker)).